### PR TITLE
Remove www. from gratipay.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub styled badge for [Gratipay][]
 
 ![Gratipay badge][]
 
-[Gratipay]: https://www.gratipay.com/
+[Gratipay]: https://gratipay.com/
 [Gratipay badge]: dist/gratipay.png
 
 ## Usage
@@ -13,13 +13,13 @@ To ensure you are using a stable badge, it is suggested you use a semver'd badge
 ### Markdown
 
 ```md
-[![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.0.1/dist/gratipay.png)](https://www.gratipay.com/USERNAME/)
+[![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.0.1/dist/gratipay.png)](https://gratipay.com/USERNAME/)
 ```
 
 ### HTML
 
 ```html
-<a href="https://www.gratipay.com/USERNAME/">
+<a href="https://gratipay.com/USERNAME/">
   <img alt="Support via Gratipay" src="https://cdn.rawgit.com/gratipay/gratipay-badge/2.0.1/dist/gratipay.png"/>
 </a>
 ```
@@ -59,7 +59,7 @@ Support this project and [others by twolfson][gratipay-twolfson] via [gratipay][
 [![Support via Gratipay][gratipay]][gratipay-twolfson]
 
 [gratipay]: https://cdn.rawgit.com/gratipay/gratipay-badge/2.0.1/dist/gratipay.png
-[gratipay-twolfson]: https://www.gratipay.com/twolfson/
+[gratipay-twolfson]: https://gratipay.com/twolfson/
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style.


### PR DESCRIPTION
@twolfson We're not using `www.` anymore since the rename.
